### PR TITLE
Adding hashing to api keys

### DIFF
--- a/apps/api/src/routes/info/info.handlers.ts
+++ b/apps/api/src/routes/info/info.handlers.ts
@@ -2,6 +2,7 @@ import type { RouteHandler } from '@hono/zod-openapi';
 import type { apiInfoRoute, keyInfoRoute } from './info.dal';
 import { db, apiKeyTable, eq } from 'db';
 import { env } from '@shared/env';
+import { sha256 } from 'hono/utils/crypto';
 
 export const apiInfoHandler: RouteHandler<typeof apiInfoRoute> = async (c) => {
   return c.json({ MAX_FILE_SIZE: env.MAX_FILE_SIZE, RATE_LIMITS: env.RATE_LIMITS, RATE_WINDOW: env.RATE_WINDOW });
@@ -9,7 +10,8 @@ export const apiInfoHandler: RouteHandler<typeof apiInfoRoute> = async (c) => {
 
 export const keyInfoHandler: RouteHandler<typeof keyInfoRoute> = async (c) => {
   const { key } = c.req.valid('param');
-  const apiKey = await db.query.apiKeyTable.findFirst({ where: eq(apiKeyTable.key, key) });
+  const hashedKey = (await sha256(key)) || '';
+  const apiKey = await db.query.apiKeyTable.findFirst({ where: eq(apiKeyTable.key, hashedKey) });
   if (!apiKey) return c.notFound();
   return c.json(apiKey);
 };

--- a/apps/api/src/utils/utils.general.ts
+++ b/apps/api/src/utils/utils.general.ts
@@ -124,9 +124,16 @@ export async function createFfmpegInstance(
 }
 
 export function writeToLog(message: string, type: 'ERROR' | 'REQUEST') {
-  const logMsg = `Date: ${new Date().toISOString()} , Type: ${type} , Message: ${message} \n\n`;
+  const timestamp = new Date().toISOString();
+  const logEntry = {
+    timestamp,
+    type,
+    message,
+  };
+
+  const formattedLog = JSON.stringify(logEntry, null, 2);
   const logFilePath = path.join(env.ROOT_DIR, '.log');
-  return appendFile(logFilePath, logMsg);
+  return appendFile(logFilePath, formattedLog + '\n');
 }
 
 export function byteToMega(bytes: number) {

--- a/apps/central/package.json
+++ b/apps/central/package.json
@@ -31,9 +31,9 @@
 	},
 	"dependencies": {
 		"@node-rs/argon2": "^1.1.0",
-		"@oslojs/crypto": "^1.0.1",
 		"@oslojs/encoding": "^1.1.0",
 		"db": "file:../../packages/db",
+		"nanoid": "^5.0.7",
 		"svelte-sonner": "^0.3.28",
 		"zod": "^3.23.8"
 	}

--- a/apps/central/pnpm-lock.yaml
+++ b/apps/central/pnpm-lock.yaml
@@ -11,15 +11,15 @@ importers:
       '@node-rs/argon2':
         specifier: ^1.1.0
         version: 1.8.3
-      '@oslojs/crypto':
-        specifier: ^1.0.1
-        version: 1.0.1
       '@oslojs/encoding':
         specifier: ^1.1.0
         version: 1.1.0
       db:
         specifier: file:../../packages/db
         version: '@gstore-org/db@file:../../packages/db'
+      nanoid:
+        specifier: ^5.0.7
+        version: 5.0.8
       svelte-sonner:
         specifier: ^0.3.28
         version: 0.3.28(svelte@5.1.13)
@@ -402,15 +402,6 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
-
-  '@oslojs/asn1@1.0.0':
-    resolution: {integrity: sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA==}
-
-  '@oslojs/binary@1.0.0':
-    resolution: {integrity: sha512-9RCU6OwXU6p67H4NODbuxv2S3eenuQ4/WFLrsq+K/k682xrznH5EVWA7N4VFk9VYVcbFtKqur5YQQZc0ySGhsQ==}
-
-  '@oslojs/crypto@1.0.1':
-    resolution: {integrity: sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ==}
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
@@ -1788,17 +1779,6 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
-
-  '@oslojs/asn1@1.0.0':
-    dependencies:
-      '@oslojs/binary': 1.0.0
-
-  '@oslojs/binary@1.0.0': {}
-
-  '@oslojs/crypto@1.0.1':
-    dependencies:
-      '@oslojs/asn1': 1.0.0
-      '@oslojs/binary': 1.0.0
 
   '@oslojs/encoding@1.1.0': {}
 

--- a/apps/central/src/lib/server/utils/auth.ts
+++ b/apps/central/src/lib/server/utils/auth.ts
@@ -1,10 +1,10 @@
 import { encodeBase32LowerCaseNoPadding, encodeHexLowerCase } from '@oslojs/encoding';
-import { sha256 } from '@oslojs/crypto/sha2';
 import { db, sessionTable, userTable, eq } from 'db';
 import type { Session } from 'db';
 import type { SessionValidationResult } from '$server/types.server';
 import type { Cookies } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
+import { sha256Hex } from './general';
 
 export function generateSessionToken(): string {
 	const bytes = new Uint8Array(20);
@@ -18,7 +18,7 @@ export async function createSession(
 	userId: string,
 	expiresAt: Date
 ): Promise<Session> {
-	const sessionId = encodeHexLowerCase(sha256(new TextEncoder().encode(token)));
+	const sessionId = encodeHexLowerCase(Uint8Array.from(sha256Hex(token)));
 	const session: Session = {
 		id: sessionId,
 		userId,
@@ -29,7 +29,7 @@ export async function createSession(
 }
 
 export async function validateSessionToken(token: string): Promise<SessionValidationResult> {
-	const sessionId = encodeHexLowerCase(sha256(new TextEncoder().encode(token)));
+	const sessionId = encodeHexLowerCase(Uint8Array.from(sha256Hex(token)));
 	const result = await db
 		.select({ user: userTable, session: sessionTable })
 		.from(sessionTable)

--- a/apps/central/src/lib/server/utils/general.ts
+++ b/apps/central/src/lib/server/utils/general.ts
@@ -1,5 +1,6 @@
 import { pathCheckModes } from '$server/const.server';
 import type { PathCheckModes } from '$server/types.server';
+import { createHash } from 'crypto';
 
 export function checkPath(
 	pathname: string,
@@ -14,4 +15,8 @@ export function checkPath(
 		if (mode == 3 && pathname === el) return true;
 	}
 	return false;
+}
+
+export function sha256Hex(input: string): string {
+	return createHash('sha256').update(input).digest('hex');
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,7 +7,7 @@
     "dev": "vite dev",
     "build": "vite build",
     "tauri-dev": "tauri dev",
-    "tauri-build": "tauri build",
+    "tauri-build": "sudo NO_STRIP=true pnpm tauri build --verbose",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",

--- a/apps/desktop/src/routes/components/addKey.svelte
+++ b/apps/desktop/src/routes/components/addKey.svelte
@@ -25,6 +25,8 @@
     const res = await tauriFetch(fetch(url), "Adding a new key");
     if (res._tag == "Left") return showToast("Error", res.left, "danger");
     const apiKey = (await res.right.json()) as ApiKey;
+    // the key in database is hashed
+    apiKey.key = tmpKey;
     if (new Date() >= new Date(apiKey.expiresAt))
       return showToast("Error", "Key has expired", "danger");
     await keysStore.set("keys", [...apiKeys, apiKey]);

--- a/packages/db/drizzle/0001_curious_joshua_kane.sql
+++ b/packages/db/drizzle/0001_curious_joshua_kane.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "apiKey" ALTER COLUMN "key" SET DATA TYPE varchar(64);--> statement-breakpoint
+ALTER TABLE "apiKey" ALTER COLUMN "key" SET NOT NULL;

--- a/packages/db/drizzle/meta/0001_snapshot.json
+++ b/packages/db/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,346 @@
+{
+  "id": "cda75073-39f3-4150-b2b7-f7972a2279da",
+  "prevId": "26018dd6-a84b-4996-ab1b-1636349d1c74",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.apiKey": {
+      "name": "apiKey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "store_id": {
+          "name": "store_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apiKey_store_id_store_id_fk": {
+          "name": "apiKey_store_id_store_id_fk",
+          "tableFrom": "apiKey",
+          "tableTo": "store",
+          "columnsFrom": [
+            "store_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "apiKey_key_unique": {
+          "name": "apiKey_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        },
+        "key_index": {
+          "name": "key_index",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        },
+        "name": {
+          "name": "name",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "store_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file": {
+      "name": "file",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(8)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extension": {
+          "name": "extension",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creation_date": {
+          "name": "creation_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_id": {
+          "name": "store_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "file_store_id_store_id_fk": {
+          "name": "file_store_id_store_id_fk",
+          "tableFrom": "file",
+          "tableTo": "store",
+          "columnsFrom": [
+            "store_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "file_index_unique": {
+          "name": "file_index_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store": {
+      "name": "store",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(8)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creation_date": {
+          "name": "creation_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "store_user_id_user_id_fk": {
+          "name": "store_user_id_user_id_fk",
+          "tableFrom": "store",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_name": {
+          "name": "unique_name",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin": {
+          "name": "admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1732382564935,
       "tag": "0000_nifty_tag",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1735755099537,
+      "tag": "0001_curious_joshua_kane",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/utils/schema.ts
+++ b/packages/db/src/utils/schema.ts
@@ -41,9 +41,7 @@ export const apiKeyTable = pgTable(
   'apiKey',
   {
     id: serial('id').primaryKey(),
-    key: varchar('key', { length: 32 })
-      .$default(() => nanoid(32))
-      .unique(),
+    key: varchar('key', { length: 64 }).notNull().unique(),
     storeId: varchar('store_id', { length: 8 })
       .notNull()
       .references(() => storeTable.id, { onDelete: 'cascade' }),


### PR DESCRIPTION
1-Hashing api keys before storing them to the database in central app
2-Updating the api to now hash the received key before checking the db for a match 
3-Updating the db schema to have a varchar(64) for sh256 key hash 
4-fixing a bug in the desktop to use the given key not received one from db since its hashed.